### PR TITLE
Add dependence spring-boot-starter-web

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
+			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Thay vì version 1 chỉ sử dụng dependency: spring-boot-starter để chạy ứng dụng spring thì v2 đã thay thế dependency này bằng: spring-boot-starter-web để cấu hình cho dự án spring web. Dependency này chứa:

- spring-boot-starter
- jackson: làm việc với Json
- spring-core
- spring-mvc
- spring-boot-starter-tomcat: cung cấp server tomcat để chạy ứng dụng